### PR TITLE
Adding my talks, and a suggestion for making it easier to find things

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,14 @@ A repository of all of the materials shared throughout the NHS-R conference 2022
 
 Please note that the materials in this repo will have a variety of licences, and no particular open licence is implied by their inclusion here. If you wish to reuse any materials in this repo you are advised to contact the author there or file an issue.
 
+## Talks
+
+* [Why Python?](https://nhs-r-community.github.io/conference-2022/talks/why-python/why-python.html)
+* [Palatable palettes: Five tips for creating and applying bespoke colour schemes | Cara Thompson](https://www.cararthompson.com/talks/nhsr2022-palatable-palettes/)
+* [Variations on a ggplot theme: Applying a unifying aesthetic to your plots | Cara Thompson](https://www.cararthompson.com/talks/nhsr2022-ggplot-themes/)
+
+## Workshops
+
+* [Build a TidyModels Classification Model from Scratch | Gary Hutson](https://github.com/nhs-r-community/conference-2022/tree/main/workshops/Build_TM_from_scratch-main)
+* [Level up your plots: a code-along workshop | Cara Thompson](https://www.cararthompson.com/talks/nhsr2022-level-up/)
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Please note that the materials in this repo will have a variety of licences, and
 
 ## Talks
 
-* [Why Python?](https://nhs-r-community.github.io/conference-2022/talks/why-python/why-python.html)
+* [Why Python? | Chris Beeley, Mary Amanuel, Craig Shenton](https://nhs-r-community.github.io/conference-2022/talks/why-python/why-python.html)
 * [Palatable palettes: Five tips for creating and applying bespoke colour schemes | Cara Thompson](https://www.cararthompson.com/talks/nhsr2022-palatable-palettes/)
 * [Variations on a ggplot theme: Applying a unifying aesthetic to your plots | Cara Thompson](https://www.cararthompson.com/talks/nhsr2022-ggplot-themes/)
 

--- a/talks/README.md
+++ b/talks/README.md
@@ -1,3 +1,5 @@
 Some of these talks can be seen by clicking the relevant links below:
 
 * [Why Python?](https://nhs-r-community.github.io/conference-2022/talks/why-python/why-python.html)
+* [Palatable palettes: Five tips for creating and applying bespoke colour schemes | Cara Thompson](https://www.cararthompson.com/talks/nhsr2022-palatable-palettes/)
+* [Variations on a ggplot theme: Applying a unifying aesthetic to your plots | Cara Thompson](https://www.cararthompson.com/talks/nhsr2022-ggplot-themes/)

--- a/talks/README.md
+++ b/talks/README.md
@@ -1,5 +1,5 @@
 Some of these talks can be seen by clicking the relevant links below:
 
-* [Why Python?](https://nhs-r-community.github.io/conference-2022/talks/why-python/why-python.html)
+* [Why Python? | Chris Beeley, Mary Amanuel, Craig Shenton](https://nhs-r-community.github.io/conference-2022/talks/why-python/why-python.html)
 * [Palatable palettes: Five tips for creating and applying bespoke colour schemes | Cara Thompson](https://www.cararthompson.com/talks/nhsr2022-palatable-palettes/)
 * [Variations on a ggplot theme: Applying a unifying aesthetic to your plots | Cara Thompson](https://www.cararthompson.com/talks/nhsr2022-ggplot-themes/)

--- a/workshops/README.md
+++ b/workshops/README.md
@@ -1,0 +1,3 @@
+Some of the workshops can be seen by clicking the relevant links below:
+
+* [Level up your plots: a code-along workshop | Cara Thompson](https://www.cararthompson.com/talks/nhsr2022-level-up/)


### PR DESCRIPTION
I thought it might be easier to find things if the talks and workshops were linked from the main README rather than READMEs within the talk / workshop folders. 

In any case, I've added links to where to find the materials I contributed to the conference. Thanks for setting this up! 